### PR TITLE
Feat/historical commitment level

### DIFF
--- a/contracts/globalParameters/GlobalParametersAlpha.sol
+++ b/contracts/globalParameters/GlobalParametersAlpha.sol
@@ -5,6 +5,10 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./IGlobalParametersAlpha.sol";
 
 contract GlobalParametersAlpha is IGlobalParametersAlpha, OwnableUpgradeable {
+
+    uint32 public constant WEEK = 7 days;
+    uint32 public constant FOUR_WEEKS = 28 days;
+
     // slot 1
     uint16 public steepnessDegree3Exp;
     uint16 public steepnessDegree3ExpStaged;
@@ -43,7 +47,7 @@ contract GlobalParametersAlpha is IGlobalParametersAlpha, OwnableUpgradeable {
 
     /// @dev fill with default values
     function initialize() external initializer {
-        periodDuration = 30 * 24 * 60 * 60;
+        periodDuration = 28 days;
         steepnessDegree3Exp = 300;
         penaltyFactor3Exp = 500;
         constrainingFactor6Exp = 1_400_000;

--- a/contracts/globalParameters/GlobalParametersAlpha.sol
+++ b/contracts/globalParameters/GlobalParametersAlpha.sol
@@ -3,11 +3,9 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./IGlobalParametersAlpha.sol";
+import { TimeLibrary } from "../libraries/TimeLibrary.sol";
 
 contract GlobalParametersAlpha is IGlobalParametersAlpha, OwnableUpgradeable {
-
-    uint32 public constant WEEK = 7 days;
-    uint32 public constant FOUR_WEEKS = 28 days;
 
     // slot 1
     uint16 public steepnessDegree3Exp;
@@ -27,13 +25,16 @@ contract GlobalParametersAlpha is IGlobalParametersAlpha, OwnableUpgradeable {
     // end of slot 1
 
     // timestamps
-    // slots 2-3
+    // slot 2
     uint64 public steepnessDegree3ExpExpiresAt;
     uint64 public penaltyFactor3ExpExpiresAt;
     uint64 public periodDurationExpiresAt;
     uint64 public constrainingFactor6ExpExpiresAt;
+
+    // Slot 3
     uint64 public credibleNeutrality6ExpExpiresAt;
-    // slot 3
+
+    uint32 public period0Start;
 
     uint256 public localReputationForPeriod0;
     uint256 public localReputationForPeriod0Staged;
@@ -47,11 +48,16 @@ contract GlobalParametersAlpha is IGlobalParametersAlpha, OwnableUpgradeable {
 
     /// @dev fill with default values
     function initialize() external initializer {
-        periodDuration = 28 days;
+        period0Start = TimeLibrary.periodStart({timestamp: block.timestamp});
+        periodDuration = TimeLibrary.FOUR_WEEKS;
         steepnessDegree3Exp = 300;
         penaltyFactor3Exp = 500;
         constrainingFactor6Exp = 1_400_000;
         credibleNeutrality6Exp = 1_300_000;
+    }
+
+    function currentPeriodId() external view returns (uint32) {
+        return TimeLibrary.periodId({ period0Start: period0Start, timestamp: block.timestamp });
     }
 
     function stagePeriodDuration(uint32 nextPeriodDuration) external {

--- a/contracts/globalParameters/IGlobalParametersAlpha.sol
+++ b/contracts/globalParameters/IGlobalParametersAlpha.sol
@@ -34,6 +34,9 @@ interface IGlobalParametersAlpha {
     event PrestigeForPeriod0Unstaged();
     event PrestiveForPeriod0Committed();
 
+    function period0Start() external view returns (uint32);
+    function currentPeriodId() external view returns (uint32);
+
     function steepnessDegree3Exp() external view returns (uint16);
     function penaltyFactor3Exp() external view returns (uint16);
     function periodDuration() external view returns (uint32);

--- a/contracts/libraries/TimeLibrary.sol
+++ b/contracts/libraries/TimeLibrary.sol
@@ -1,0 +1,26 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+library TimeLibrary {
+    uint32 internal constant WEEK = 7 days;
+    uint32 internal constant FOUR_WEEKS = 28 days;
+
+    function periodStart(uint32 timestamp) internal pure returns (uint32) {
+        unchecked {
+            return timestamp - (timestamp % FOUR_WEEKS);
+        }
+    }
+
+    function periodEnd(uint32 timestamp) internal pure returns (uint32) {
+        unchecked {
+            return periodStart({timestamp: timestamp}) + FOUR_WEEKS;
+        }
+    }
+
+    /// @dev returns the id of the curent period, starting at 1
+    function periodId(uint32 period0Start, uint32 timestamp) internal pure returns (uint32) {
+        unchecked {
+            ((periodStart({timestamp: timestamp}) - period0Start) / FOUR_WEEKS) + 1;
+        }
+    }
+}

--- a/contracts/nova/INova.sol
+++ b/contracts/nova/INova.sol
@@ -7,6 +7,9 @@ interface INova {
     error NotDeployer();
     error NotAdmin();
     error NotMember();
+    error MemberHasNotYetCommitted();
+    error MemberHasNotJoinedHub();
+    error SameCommitmentLevel();
 
     event AdminGranted(address to);
     event AdminRenounced(address from);
@@ -19,6 +22,7 @@ interface INova {
     event OnboardingSet(address);
     event MarketSet(uint256);
     event CommitmentSet(uint256);
+    event ChangeCommitmentLevel(address indexed who, uint32 oldCommitmentLevel, uint32 newCommitmentLevel);
 
     function registerDomain(string calldata domain, address novaAddress, string calldata metadataUri) external;
     function getDomain(string calldata domain) external view returns (address, string memory);

--- a/contracts/nova/Nova.sol
+++ b/contracts/nova/Nova.sol
@@ -35,9 +35,12 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     uint256 public market;
     string public metadataUri;
 
+    uint32 public initTimestamp;
+    uint32 public initPeriodId;
+
     mapping(address => uint256) public roles;
     mapping(address => uint256) public joinedAt;
-    mapping(address => uint256) public commitmentLevels;
+    mapping(address => uint256) public currentCommitmentLevel;
     mapping(uint256 => uint256) public parameterWeight;
     mapping(address => uint256) public accountMasks;
 
@@ -52,11 +55,6 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
                 Participation participation
         )
     ) public participations;
-
-    mapping(
-        address who => 
-            uint32 periodId
-    ) public lastPeriodIdCommitmentLevelChanged;
 
     string[] private _urls;
     mapping(bytes32 => uint256) private _urlHashIndex;
@@ -75,7 +73,6 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         uint256 commitment_,
         string memory metadataUri_,
         address hubDomainsRegistry_
-
     ) external initializer {
         _setMaskPosition(deployer_, ADMIN_MASK_POSITION);
         /// @custom:sdk-legacy-interface-compatibility
@@ -88,6 +85,9 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         novaRegistry = novaRegistry_;
         hubDomainsRegistry = hubDomainsRegistry_;
         deployer = deployer_;
+
+        initTimestamp = block.timestamp;
+        initPeriodId = IGlobalParametersAlpha(novaRegistry_).currentPeriodId();
     }
 
     function setMetadataUri(string memory uri) external {
@@ -134,9 +134,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         commitmentLevels[who] = commitmentLevel;
         members.push(who);
         joinedAt[who] = block.timestamp;
+
         uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
         partipications[msg.sender][currentPeriodId].commitmentLevel = commitmentLevel;
-        lastPeriodIdCommitmentLevelChanged[msg.sender] = currentPeriodId;
+        currentCommitmentLevel[msg.sender] = currentPeriodId;
 
         INovaRegistry(novaRegistry).joinNovaHook(who);
 
@@ -147,14 +148,14 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     function getCommitmentLevel(address who, uint32 periodId) external view returns (uint32) {
         if (periodId < getPeriodIdJoined(who)) revert UserHasNotYetCommited();
 
-        Participation memory p = ;
-        if (lastPeriodIdCommitmentLevelChanged[who] < periodId) {
-            // User has the same commitment level as previously set
-            return getCurrentCommitmentLevel(who);
+        Participation memory participation = participations[who];
+        if (participation.commitmentLevel != 0) {
+            // user has changed their commitmentLevel in a period following `periodId`.  We know this becuase
+            // participation.commitmentLevel state is non-zero as it is written following a commitmentLevel change.
+            return participation.commitmentLevel;
         } else {
-            // User has changed their commitment level more recently than the periodId,
-            // meaning we have written to storage their previous commitment level
-            return participations[who][period].commitmentLevel;
+            // User has *not* changed their commitment level: meaning their commitLevel is sync to current
+            return currentCommitmentLevel[who];
         }
     }
 
@@ -168,30 +169,28 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         return periodIdJoined;
     }
 
-    /// @notice get the most recently set commitment level
-    function getCurrentCommitmentLevel(address who) public view returns (uint32) {
-        uint32 lastPeriodIdChanged = lastPeriodIdCommitmentLevelChanged[who];
-        if (lastPeriodIdChanged == 0) revert MemberHasNotJoinedHub();
-        
-        return participations[who][lastPeriodIdChanged].commitmentLevel;
-    }
-
     function changeCommitmentLevel(uint32 newCommitmentLevel) external {
-        uint32 lastPeriodIdChanged = lastPeriodIdCommitmentLevelChanged[who];
-        if (lastPeriodIdChanged == 0) revert MemberHasNotJoinedHub();
-        
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).getCurrentPeriodId();
-
-        uint32 oldCommitmentLevel = participations[msg.sender][lastPeriodIdChanged].commitmentLevel;
+        uint32 oldCommitmentLevel = currentCommitmentLevel[msg.sender];
         if (newCommitmentLevel == oldCommitmentLevel) revert SameCommitmentLevel();
 
-        // Write to storage for all zero values up to the current period with the old commitment level
-        for (uint256 i=lastPeriodIdChanged+1; i<currentPeriodId+1; i++) {
-            participations[msg.sender][i].commitmentLevel = oldCommitmentLevel;
+        // TODO: globalParam
+        if (newCommitmentLevel == 0 || newCommitmentLevel > 10) revert InvalidCommitmentLevel();
+
+        uint32 periodIdJoined = getPeriodIdJoined(msg.sender);
+        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+
+        // write to storage for all 0 values- as the currentCommitmentLevel is now different
+        for (uint256 i=currentPeriodId; i>periodIdJoined - 1; i--) {
+            Participation storage participation = participations[msg.sender][i];
+            if (participation.commitmentLevel == 0) {
+                participation.commitmentLevel = oldCommitmentLevel;
+            } else {
+                // we have reached the end of zero values
+                break;
+            }
         }
 
-        // Store the new commitment level in the next period id
-        partipications[msg.sender][currentPeriodId + 1] = newCommitmentLevel;
+        currentCommitmentLevel[msg.sender] = newCommitmentLevel;
 
         emit ChangeCommitmentLevel({
             who: msg.sender,

--- a/contracts/nova/NovaRegistry.sol
+++ b/contracts/nova/NovaRegistry.sol
@@ -11,6 +11,7 @@ import {
 
 import {IModuleRegistry} from "../modules/registry/IModuleRegistry.sol";
 import {INovaRegistry} from "./INovaRegistry.sol";
+import {IGlobalParametersAlpha} from "../globalParameters/IGlobalParametersAlpha.sol";
 import {IAllowlist} from "../utils/IAllowlist.sol";
 import {Nova} from "../nova/Nova.sol";
 
@@ -31,12 +32,19 @@ contract NovaRegistry is INovaRegistry, ERC2771ContextUpgradeable, OwnableUpgrad
     address public autIDAddr;
     address public pluginRegistry;
     address public hubDomainsRegistry;
+    address public glogalParameters;
     UpgradeableBeacon public upgradeableBeacon;
     IAllowlist public allowlist;
 
     constructor(address trustedForwarder_) ERC2771ContextUpgradeable(trustedForwarder_) {}
 
-    function initialize(address autIDAddr_, address novaLogic, address pluginRegistry_, address hubDomainsRegistry_) external initializer {
+    function initialize(
+        address autIDAddr_,
+        address novaLogic,
+        address pluginRegistry_,
+        address hubDomainsRegistry_,
+        address globalParameters_
+    ) external initializer {
         require(autIDAddr_ != address(0), "NovaRegistry: AutID address zero");
         require(novaLogic != address(0), "NovaRegistry: Nova logic address zero");
         require(pluginRegistry_ != address(0), "NovaRegistry: PluginRegistry address zero");
@@ -46,9 +54,18 @@ contract NovaRegistry is INovaRegistry, ERC2771ContextUpgradeable, OwnableUpgrad
         autIDAddr = autIDAddr_;
         pluginRegistry = pluginRegistry_;
         hubDomainsRegistry = hubDomainsRegistry_;
+        globalParameters = globalParameters_;
         upgradeableBeacon = new UpgradeableBeacon(novaLogic, address(this));
         // allowlist =
         // IAllowlist(IModuleRegistry(IPluginRegistry(pluginRegistry_).modulesRegistry()).getAllowListAddress());
+    }
+
+    function currentPeriodId() external view returns (uint32) {
+        return IGlobalParametersAlpha(globalParameters).currentPeriodId();
+    }
+
+    function period0Start() external view returns (uint32) {
+        return IGlobalParametersAlpha(globalParameters).period0Start();
     }
 
     // the only reason for this function is to keep interface compatible with sdk


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
- Normalize period to a predictable duration.
- Provide interface to track current / historical period and commitment level.
- Allow hub members to update their commitment level.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- Have a period id starting at 1 so that Hubs created in the first period can look at their TCp from id 0 (which will, by default, be 0).
  - Each historical period can now be tracked / indexed by its' id.
- Convert period to 28 days.
  - This means every four weeks at exactly Wednesday 00:00 UTC, the period id will increase by 1.

Resolves #94.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
