### PR TITLE
wip: 1155

### DIFF
--- a/contracts/interactions/InteractionFactory.sol
+++ b/contracts/interactions/InteractionFactory.sol
@@ -3,18 +3,25 @@ pragma solidity ^0.8.20;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {
-    ERC721Upgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+    ERC1155Upgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {
-    ERC721URIStorageUpgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+    ERC1155URIStorageUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol";
+import {
+    ERC1155SupplyUpgradeable
+} from "@openzeppelin/contracts-upgradeable/token/ERC1155/extensions/ERC1155SupplyUpgradeable.sol";
 import {
     AccessControlUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 
-/// @title a ERC721 upgradeable contract with metadata contract for interactions
-contract InteractionFactory is ERC721URIStorageUpgradeable, AccessControlUpgradeable {
+/// @title a ERC1155 upgradeable contract with metadata contract for interactions
+contract InteractionFactory is
+    ERC1155URIStorageUpgradeable,
+    ERC1155SupplyUpgradeable,
+    AccessControlUpgradeable
+{
     /// @notice en event emmited on interactionURI update
     /// @param sender sender address of the update
     /// @param interactionId id of interaction
@@ -40,20 +47,33 @@ contract InteractionFactory is ERC721URIStorageUpgradeable, AccessControlUpgrade
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
     /// @notice a role that manage minting
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    /// @notice role to manage token URI
+    bytes32 public constant URI_ROLE = keccak256("URI");
 
     /// @notice a variable that indicates whether tokens are non-transferable
     bool public isNonTransferable = false;
     /// @notice a variable that stores mint timestamps for each interaction id
-    mapping(uint256 interactionId => uint64 timestamp) public mintedAt;
+    mapping(
+        uint256 interactionId => mapping(
+            uint256 id => 
+                uint64 timestamp
+        )
+    ) public mintedAt;
+
+    constructor() {
+        _disableInitializers();
+    }
 
     function initialize(address initialManager) public initializer {
         if (address(initialManager) == address(0)) {
             revert InitialManagerEmptyError();
         }
-        __ERC721_init("InteractionFactory", "IF");
+        __ERC1155_init(""); // TODO: URI
         _setRoleAdmin(MINTER_ROLE, MANAGER_ROLE);
+        _setRoleAdmin(URI_ROLE, MANAGER_ROLE);
         _grantRole(MANAGER_ROLE, initialManager);
         _grantRole(MINTER_ROLE, initialManager);
+        _grantRole(URI_ROLE, initialManager);
     }
 
     /// @notice enable or disable transferability of the whole collection
@@ -67,59 +87,44 @@ contract InteractionFactory is ERC721URIStorageUpgradeable, AccessControlUpgrade
     /// @notice mint interaction
     /// @param to address of the recipient of the interaction token
     /// @param interactionId id of the interaction
-    /// @param uri tokenURI
     function mintInteraction(
         address to,
-        uint256 interactionId,
-        string memory uri
+        uint256 interactionId
     ) external {
         _checkRole(MINTER_ROLE);
-        _mint(to, interactionId);
-        _setInteractionURI(interactionId, uri);
-        mintedAt[interactionId] = uint64(block.timestamp);
+        _mint(to, interactionId, 1, "");
+        mintedAt[interactionId][totalSupply(interactionId)] = uint64(block.timestamp);
         emit InteractionMinted(to, interactionId);
     }
 
     /// @notice update tokenURI for the interaction by the owner of interaction token
     /// @param interactionId id of the interaction
-    /// @param uri new tokenURI
-    function updateInteractionURI(uint256 interactionId, string memory uri) external {
-        if (bytes(uri).length == 0) {
+    /// @param interactionUri new interaction URI
+    function updateInteractionURI(uint256 interactionId, string memory interactionUri) external {
+        if (bytes(interactionUri).length == 0) {
             revert MetadataURIEmptyError();
         }
-        address owner = _ownerOf(interactionId);
-        _checkAuthorized(owner, msg.sender, interactionId);
-        _setInteractionURI(interactionId, uri);
+        _checkRole(URI_ROLE);
+        _setInteractionURI(interactionId, interactionUri);
     }
 
-    /// @inheritdoc IERC721
-    function transferFrom(
+    /// @inheritdoc IERC1155
+    function safeTransferFrom(
         address from,
         address to,
-        uint256 tokenId
-    ) public virtual override(ERC721Upgradeable, IERC721) {
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) public virtual override(ERC1155Upgradeable, IERC1155) {
         if (isNonTransferable) {
             revert TransferUnallowedError();
         } else {
-            super.transferFrom(from, to, tokenId);
+            super.safeTransferFrom(from, to, id, value, data);
         }
     }
 
-    /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceId
-    )
-        public
-        view
-        override(ERC721URIStorageUpgradeable, AccessControlUpgradeable)
-        returns (bool)
-    {
-        return (ERC721URIStorageUpgradeable.supportsInterface(interfaceId) ||
-            AccessControlUpgradeable.supportsInterface(interfaceId));
-    }
-
-    function _setInteractionURI(uint256 interactionId, string memory uri) internal {
-        _setTokenURI(interactionId, uri);
-        emit InteractionURIUpdated(msg.sender, interactionId, uri);
+    function _setInteractionURI(uint256 interactionId, string memory interactionUri) internal {
+        _setURI(interactionId, interactionUri);
+        emit InteractionURIUpdated(msg.sender, interactionId, interactionUri);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Convert interactions from 721 to 1155.  This will enable re-use of interactions across tasks, allowing the distribution and collection of the same interaction across hub members.

### Remaining
- Integrate dynamic bytes to `IntegrationId` to allow the same interaction with different requirement data.

### Questions:
- Should the supply of task (say, 100) mint 100 interaction NFTs at the time of task creation?  Or, should the interaction NFT be minted at time of task completion?
- Who is in charge of choosing the URI behind the interaction?
- What, if any, data regarding task completion should be stored within the Hub?  A user will be able to see this interaction contract for their completed interaction. However, does a user need to see task metadata from the hub?  Do we need to store metadata from the task completion to a user's historical participation?

@Jabyl 



@Jabyl  

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
