### PR TITLE
refactor: rm HubRegistry dep from Hub

### DIFF
--- a/contracts/autid/AutID.sol
+++ b/contracts/autid/AutID.sol
@@ -145,12 +145,7 @@ contract AutID is AutIDUtils, ERC721URIStorageUpgradeable, OwnableUpgradeable, E
         _revertForCanNotJoinNova(nova, account, role);
         _revertForMinCommitmentNotReached(nova, commitment);
 
-        INovaRegistry(novaRegistryAddress).join({
-            nova: nova,
-            member: account,
-            role: role,
-            commitment: commitment
-        });
+        INovaRegistry(novaRegistryAddress).join({nova: nova, member: account, role: role, commitment: commitment});
         INova(nova).join(account, role, commitment);
 
         emit NovaJoined(account, role, commitment, nova);

--- a/contracts/autid/AutID.sol
+++ b/contracts/autid/AutID.sol
@@ -145,6 +145,12 @@ contract AutID is AutIDUtils, ERC721URIStorageUpgradeable, OwnableUpgradeable, E
         _revertForCanNotJoinNova(nova, account, role);
         _revertForMinCommitmentNotReached(nova, commitment);
 
+        INovaRegistry(novaRegistryAddress).join({
+            nova: nova,
+            member: account,
+            role: role,
+            commitment: commitment
+        });
         INova(nova).join(account, role, commitment);
 
         emit NovaJoined(account, role, commitment, nova);

--- a/contracts/nova/INovaRegistry.sol
+++ b/contracts/nova/INovaRegistry.sol
@@ -8,7 +8,7 @@ interface INovaRegistry {
 
     function deployNova(uint256 market, string memory metadata, uint256 commitment) external returns (address nova);
 
-    function joinNovaHook(address user) external;
+    function join(address nova, address member, uint256 role, uint8 commitment) external;
 
     function listUserNovas(address user) external view returns (address[] memory);
 

--- a/contracts/nova/Nova.sol
+++ b/contracts/nova/Nova.sol
@@ -5,7 +5,6 @@ import {OnboardingModule} from "../modules/onboarding/OnboardingModule.sol";
 import {NovaUpgradeable} from "./NovaUpgradeable.sol";
 import {NovaUtils} from "./NovaUtils.sol";
 import {INova} from "./INova.sol";
-import {INovaRegistry} from "./INovaRegistry.sol";
 import "../hubContracts/IHubDomainsRegistry.sol";
 import {IGlobalParametersAlpha} from "../globalParameters/IGlobalParametersAlpha.sol";
 import {IInteractionRegistry} from "../interactions/InteractionRegistry.sol";
@@ -26,7 +25,6 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     uint8 public constant ADMIN_MASK_POSITION = 1;
 
     address public autID;
-    address public novaRegistry;
     address public hubDomainsRegistry;
     address public pluginRegistry;
     address public onboarding;
@@ -39,6 +37,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     uint32 public initTimestamp;
     uint32 public initPeriodId;
+    uint32 public period0Start;
 
     mapping(address => uint256) public roles;
     mapping(address => uint32) public joinedAt;
@@ -106,12 +105,12 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         _setMetadataUri(metadataUri_);
         pluginRegistry = pluginRegistry_;
         autID = autID_;
-        novaRegistry = novaRegistry_;
         hubDomainsRegistry = hubDomainsRegistry_;
         deployer = deployer_;
 
         initTimestamp = uint32(block.timestamp);
         initPeriodId = IGlobalParametersAlpha(novaRegistry_).currentPeriodId();
+        period0Start = IGlobalParametersAlpha(novaRegistry_).period0Start();
     }
 
     function setMetadataUri(string memory uri) external {
@@ -158,7 +157,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         members.push(who);
         joinedAt[who] = uint32(block.timestamp);
 
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         participations[who][currentPeriodId] = Participation({
             commitmentLevel: commitmentLevel,
             givenContributionPoints: 0,
@@ -169,8 +171,6 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
         _writePeriodSummary(currentPeriodId);
         currentSumCommitmentLevel += uint128(commitmentLevel);
-
-        INovaRegistry(novaRegistry).joinNovaHook(who);
 
         emit MemberGranted(who, role);
     }
@@ -193,7 +193,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     /// @notice return the period id the member joined the hub
     function getPeriodIdJoined(address who) public view returns (uint32) {
         uint32 periodIdJoined = TimeLibrary.periodId({
-            period0Start: IGlobalParametersAlpha(novaRegistry).period0Start(),
+            period0Start: period0Start,
             timestamp: joinedAt[who]
         });
         if (periodIdJoined == 0) revert MemberDoesNotExist();
@@ -208,7 +208,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         if (newCommitmentLevel == 0 || newCommitmentLevel > 10) revert InvalidCommitmentLevel();
 
         uint32 periodIdJoined = getPeriodIdJoined(msg.sender);
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
 
         // write to storage for all 0 values- as the currentCommitmentLevels is now different
         for (uint32 i = currentPeriodId; i > periodIdJoined - 1; i--) {
@@ -235,7 +238,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     function writeParticipations(address[] calldata whos) external {
         // update historical periods if necessary
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         _writePeriodSummary(currentPeriodId);
 
         for (uint256 i = 0; i < whos.length; i++) {
@@ -245,7 +251,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     function writeParticipation(address who) external {
         // update historical periods if necessary
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         _writePeriodSummary(currentPeriodId);
 
         _writeParticipation(who, currentPeriodId);
@@ -317,7 +326,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         uint128 givenContributionPoints,
         uint32 periodId
     ) public view returns (uint128) {
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return
             _calcPerformanceInPeriod({
@@ -343,7 +355,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     /// @dev returned with 1e18 precision
     function calcPerformanceInPeriod(address who, uint32 periodId) public view returns (uint128) {
         _revertForNotMember(who);
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return _calcPerformanceInPeriod(who, periodId);
     }
@@ -360,7 +375,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     // fiCL * TCP
     function calcExpectedContributionPoints(uint32 commitmentLevel, uint32 periodId) public view returns (uint128) {
         if (commitmentLevel < 1 || commitmentLevel > 10) revert InvalidCommitmentLevel();
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return _calcExpectedContributionPoints(commitmentLevel, periodId);
     }
@@ -374,7 +392,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     /// @notice write sums to history when needed
     function writePeriodSummary() public {
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         _writePeriodSummary(currentPeriodId);
     }
 
@@ -492,7 +513,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     function _addTask(Task memory _task) internal {
         if (_task.contributionPoints == 0 || _task.contributionPoints > 10) revert InvalidTaskContributionPoints();
         if (_task.quantity == 0 || _task.quantity > members.length + 100) revert InvalidTaskQuantity();
-        if (!IInteractionRegistry(novaRegistry).isInteractionId(_task.interactionId)) revert InvalidTaskInteractionId();
+        // if (!IInteractionRegistry(novaRegistry).isInteractionId(_task.interactionId)) revert InvalidTaskInteractionId();
 
         uint128 sumTaskContributionPoints = _task.contributionPoints * _task.quantity;
         currentSumActiveContributionPoints += sumTaskContributionPoints;
@@ -548,7 +569,10 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         if (task.quantity == 0) revert TaskNotActive();
         if (joinedAt[_member] == 0) revert MemberDoesNotExist();
 
-        uint32 currentPeriodId = IGlobalParametersAlpha(novaRegistry).currentPeriodId();
+        uint32 currentPeriodId = TimeLibrary.periodId({
+            period0Start: period0Start,
+            timestamp: uint32(block.timestamp)
+        });
         Participation storage participation = participations[_member][currentPeriodId];
 
         uint128 contributionPoints = task.contributionPoints;

--- a/contracts/nova/Nova.sol
+++ b/contracts/nova/Nova.sol
@@ -157,10 +157,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         members.push(who);
         joinedAt[who] = uint32(block.timestamp);
 
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         participations[who][currentPeriodId] = Participation({
             commitmentLevel: commitmentLevel,
             givenContributionPoints: 0,
@@ -192,10 +189,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     /// @notice return the period id the member joined the hub
     function getPeriodIdJoined(address who) public view returns (uint32) {
-        uint32 periodIdJoined = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: joinedAt[who]
-        });
+        uint32 periodIdJoined = TimeLibrary.periodId({period0Start: period0Start, timestamp: joinedAt[who]});
         if (periodIdJoined == 0) revert MemberDoesNotExist();
         return periodIdJoined;
     }
@@ -208,10 +202,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         if (newCommitmentLevel == 0 || newCommitmentLevel > 10) revert InvalidCommitmentLevel();
 
         uint32 periodIdJoined = getPeriodIdJoined(msg.sender);
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
 
         // write to storage for all 0 values- as the currentCommitmentLevels is now different
         for (uint32 i = currentPeriodId; i > periodIdJoined - 1; i--) {
@@ -238,10 +229,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     function writeParticipations(address[] calldata whos) external {
         // update historical periods if necessary
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         _writePeriodSummary(currentPeriodId);
 
         for (uint256 i = 0; i < whos.length; i++) {
@@ -251,10 +239,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     function writeParticipation(address who) external {
         // update historical periods if necessary
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         _writePeriodSummary(currentPeriodId);
 
         _writeParticipation(who, currentPeriodId);
@@ -326,10 +311,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         uint128 givenContributionPoints,
         uint32 periodId
     ) public view returns (uint128) {
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return
             _calcPerformanceInPeriod({
@@ -355,10 +337,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     /// @dev returned with 1e18 precision
     function calcPerformanceInPeriod(address who, uint32 periodId) public view returns (uint128) {
         _revertForNotMember(who);
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return _calcPerformanceInPeriod(who, periodId);
     }
@@ -375,10 +354,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
     // fiCL * TCP
     function calcExpectedContributionPoints(uint32 commitmentLevel, uint32 periodId) public view returns (uint128) {
         if (commitmentLevel < 1 || commitmentLevel > 10) revert InvalidCommitmentLevel();
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         if (periodId == 0 || periodId > currentPeriodId) revert InvalidPeriodId();
         return _calcExpectedContributionPoints(commitmentLevel, periodId);
     }
@@ -392,10 +368,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
 
     /// @notice write sums to history when needed
     function writePeriodSummary() public {
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         _writePeriodSummary(currentPeriodId);
     }
 
@@ -455,7 +428,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         PeriodSummary memory periodSummary = periodSummaries[periodId];
         if (periodSummary.isSealed) return false;
         uint256 length = members.length;
-        for (uint256 i=0; i<length; i++) {
+        for (uint256 i = 0; i < length; i++) {
             if (participations[members[i]][periodId].score == 0) {
                 return false;
             }
@@ -467,7 +440,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         uint256 numMembersToWrite = 0;
         uint256 length = members.length;
         address[] memory membersCopy = new address[](length);
-        for (uint256 i=0; i<length; i++) {
+        for (uint256 i = 0; i < length; i++) {
             address member = members[i];
             if (participations[member][periodId].score == 0) {
                 membersCopy[numMembersToWrite++] = member;
@@ -475,7 +448,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         }
 
         address[] memory arrMembersToWrite = new address[](numMembersToWrite);
-        for (uint256 i=0; i<numMembersToWrite; i++) {
+        for (uint256 i = 0; i < numMembersToWrite; i++) {
             arrMembersToWrite[i] = membersCopy[i];
         }
         return arrMembersToWrite;
@@ -569,10 +542,7 @@ contract Nova is INova, NovaUtils, NovaUpgradeable {
         if (task.quantity == 0) revert TaskNotActive();
         if (joinedAt[_member] == 0) revert MemberDoesNotExist();
 
-        uint32 currentPeriodId = TimeLibrary.periodId({
-            period0Start: period0Start,
-            timestamp: uint32(block.timestamp)
-        });
+        uint32 currentPeriodId = TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
         Participation storage participation = participations[_member][currentPeriodId];
 
         uint128 contributionPoints = task.contributionPoints;

--- a/contracts/nova/NovaRegistry.sol
+++ b/contracts/nova/NovaRegistry.sol
@@ -14,7 +14,7 @@ import {INovaRegistry} from "./INovaRegistry.sol";
 import {IInteractionRegistry} from "../interactions/InteractionRegistry.sol";
 import {IGlobalParametersAlpha} from "../globalParameters/IGlobalParametersAlpha.sol";
 import {IAllowlist} from "../utils/IAllowlist.sol";
-import {Nova} from "../nova/Nova.sol";
+import {INova, Nova} from "../nova/Nova.sol";
 
 /// @title NovaRegistry
 contract NovaRegistry is INovaRegistry, ERC2771ContextUpgradeable, OwnableUpgradeable {
@@ -116,9 +116,20 @@ contract NovaRegistry is INovaRegistry, ERC2771ContextUpgradeable, OwnableUpgrad
         return _userNovaList[user];
     }
 
-    function joinNovaHook(address member) external {
-        address nova = msg.sender;
+    function join(
+        address nova,
+        address member,
+        uint256 role,
+        uint8 commitment
+    ) external {
         require(checkNova[nova], "NovaRegistry: sender not a nova");
+        
+        INova(nova).join({
+            who: member,
+            role: role,
+            commitmentLevel: commitment
+        });
+        
         uint256 position = _userNovaList[member].length;
         _userNovaList[member].push(nova);
         _userNovaListIds[member][nova] = position;

--- a/contracts/nova/NovaRegistry.sol
+++ b/contracts/nova/NovaRegistry.sol
@@ -116,20 +116,11 @@ contract NovaRegistry is INovaRegistry, ERC2771ContextUpgradeable, OwnableUpgrad
         return _userNovaList[user];
     }
 
-    function join(
-        address nova,
-        address member,
-        uint256 role,
-        uint8 commitment
-    ) external {
+    function join(address nova, address member, uint256 role, uint8 commitment) external {
         require(checkNova[nova], "NovaRegistry: sender not a nova");
-        
-        INova(nova).join({
-            who: member,
-            role: role,
-            commitmentLevel: commitment
-        });
-        
+
+        INova(nova).join({who: member, role: role, commitmentLevel: commitment});
+
         uint256 position = _userNovaList[member].length;
         _userNovaList[member].push(nova);
         _userNovaListIds[member][nova] = position;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
Cleans up dependency issues mentioned in #106 by removing storage of the HubRegistry in the Hub.  This greatly simplifies calculations and data storage.

Maintains the `joinNovaHook()` by calling `join()` through the `Registry` first, which then delegates to the underlying `Hub`, a proper call flow.

cc @Jabyl 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
