### PR TITLE
feat: contribution manager

### DIFF
--- a/contracts/tasks/TaskManager.sol
+++ b/contracts/tasks/TaskManager.sol
@@ -23,7 +23,7 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     mapping(address member => EnumerableSet.Bytes32Set) private memberContributions;
     mapping(uint32 periodId => bytes32[] contributionIds) public contributionsGivenInPeriod;
 
-    EnumerableSet.AddressSet private _contributors;
+    EnumerableSet.AddressSet private _contributionManagers;
 
     constructor() {
         _disableInitializers();
@@ -34,28 +34,28 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
         _init_PeriodUtils({_period0Start: _period0Start, _initPeriodId: _initPeriodId});
     }
 
-    // Contributor-management
+    // ContributionManager-management
 
-    function addContributor(address who) external {
+    function addContributionManager(address who) external {
         _revertIfNotAdmin();
-        if (!_contributors.add(who)) revert AlreadyContributor();
+        if (!_contributionManagers.add(who)) revert AlreadyContributionManager();
 
-        emit AddContributor(who);
+        emit AddContributionManager(who);
     }
 
-    function removeContributor(address who) external {
+    function removeContributionManager(address who) external {
         _revertIfNotAdmin();
-        if (!_contributors.remove(who)) revert NotContributor();
+        if (!_contributionManagers.remove(who)) revert NotContributionManager();
 
-        emit RemoveContributor(who);
+        emit RemoveContributionManager(who);
     }
 
-    function isContributor(address who) public view returns (bool) {
-        return _contributors.contains(who);
+    function isContributionManager(address who) public view returns (bool) {
+        return _contributionManagers.contains(who);
     }
 
-    function contributors() external view returns (address[] memory) {
-        return _contributors.values();
+    function contributionManagers() external view returns (address[] memory) {
+        return _contributionManagers.values();
     }
 
     // Contribution-management
@@ -123,7 +123,8 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     }
 
     function _commitContribution(bytes32 contributionId, address who, bytes memory data) internal {
-        if (msg.sender != who && !isContributor(msg.sender) && !_isAdmin(msg.sender)) revert UnauthorizedContributor();
+        if (msg.sender != who && !isContributionManager(msg.sender) && !_isAdmin(msg.sender))
+            revert UnauthorizedContributionManager();
         _revertIfNotMember(who);
 
         ContributionStatus storage contributionStatus = contributionStatuses[contributionId];
@@ -132,7 +133,7 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     }
 
     function giveContributions(bytes32[] calldata contributionIds, address[] calldata whos) external {
-        if (!isContributor(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributor();
+        if (!isContributionManager(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributionManager();
         writePointSummary();
 
         uint256 length = contributionIds.length;
@@ -143,7 +144,7 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     }
 
     function giveContribution(bytes32 contributionId, address who) external {
-        if (!isContributor(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributor();
+        if (!isContributionManager(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributionManager();
         writePointSummary();
         _giveContribution(contributionId, who);
     }

--- a/contracts/tasks/TaskManager.sol
+++ b/contracts/tasks/TaskManager.sol
@@ -11,6 +11,7 @@ import {Contribution} from "./interfaces/ITaskFactory.sol";
 
 contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     using EnumerableSet for EnumerableSet.Bytes32Set;
+    using EnumerableSet for EnumerableSet.AddressSet;
 
     uint128 public pointsActive;
     uint128 public periodPointsGiven;
@@ -22,6 +23,8 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     mapping(address member => EnumerableSet.Bytes32Set) private memberContributions;
     mapping(uint32 periodId => bytes32[] contributionIds) public contributionsGivenInPeriod;
 
+    EnumerableSet.AddressSet private _contributors;
+
     constructor() {
         _disableInitializers();
     }
@@ -30,6 +33,32 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
         _init_AccessUtils({_hub: _hub, _autId: address(0)});
         _init_PeriodUtils({_period0Start: _period0Start, _initPeriodId: _initPeriodId});
     }
+
+    // Contributor-management
+
+    function addContributor(address who) external {
+        _revertIfNotAdmin();
+        if (!_contributors.add(who)) revert AlreadyContributor();
+
+        emit AddContributor(who);
+    }
+
+    function removeContributor(address who) external {
+        _revertIfNotAdmin();
+        if (!_contributors.remove(who)) revert NotContributor();
+
+        emit RemoveContributor(who);
+    }
+
+    function isContributor(address who) public view returns (bool) {
+        return _contributors.contains(who);
+    }
+
+    function contributors() external view returns (address[] memory) {
+        return _contributors.values();
+    }
+
+    // Contribution-management
 
     function addContribution(bytes32 contributionId, Contribution calldata contribution) public {
         _revertIfNotTaskFactory();
@@ -77,28 +106,33 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
         emit RemoveContribution(contributionId, encodeContributionStatus(contributionStatus));
     }
 
-    function commitContributions(bytes32[] calldata contributionIds, bytes[] calldata datas) external {
-        _revertIfNotMember(msg.sender);
+    function commitContributions(
+        bytes32[] calldata contributionIds,
+        address[] calldata whos,
+        bytes[] calldata datas
+    ) external {
         uint256 length = contributionIds.length;
-        if (length != datas.length) revert UnequalLengths();
+        if (length != whos.length || length != datas.length) revert UnequalLengths();
         for (uint256 i = 0; i < length; i++) {
-            _commitContribution(contributionIds[i], datas[i]);
+            _commitContribution(contributionIds[i], whos[i], datas[i]);
         }
     }
 
-    function commitContribution(bytes32 contributionId, bytes calldata data) external {
-        _revertIfNotMember(msg.sender);
-        _commitContribution(contributionId, data);
+    function commitContribution(bytes32 contributionId, address who, bytes calldata data) external {
+        _commitContribution(contributionId, who, data);
     }
 
-    function _commitContribution(bytes32 contributionId, bytes memory data) internal {
+    function _commitContribution(bytes32 contributionId, address who, bytes memory data) internal {
+        if (msg.sender != who && !isContributor(msg.sender) && !_isAdmin(msg.sender)) revert UnauthorizedContributor();
+        _revertIfNotMember(who);
+
         ContributionStatus storage contributionStatus = contributionStatuses[contributionId];
         if (uint8(contributionStatus.status) != uint8(Status.Open)) revert ContributionNotOpen();
-        emit CommitContribution(contributionId, msg.sender, data);
+        emit CommitContribution(contributionId, msg.sender, who, data);
     }
 
     function giveContributions(bytes32[] calldata contributionIds, address[] calldata whos) external {
-        _revertIfNotAdmin();
+        if (!isContributor(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributor();
         writePointSummary();
 
         uint256 length = contributionIds.length;
@@ -109,7 +143,7 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     }
 
     function giveContribution(bytes32 contributionId, address who) external {
-        _revertIfNotAdmin();
+        if (!isContributor(msg.sender) && _isAdmin(msg.sender)) revert UnauthorizedContributor();
         writePointSummary();
         _giveContribution(contributionId, who);
     }

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -31,12 +31,12 @@ interface ITaskManager {
     error UnequalLengths();
     error MemberAlreadyContributed();
     error ContributionNotOpen();
-    error AlreadyContributor();
-    error NotContributor();
-    error UnauthorizedContributor();
+    error AlreadyContributionManager();
+    error NotContributionManager();
+    error UnauthorizedContributionManager();
 
-    event AddContributor(address who);
-    event RemoveContributor(address who);
+    event AddContributionManager(address who);
+    event RemoveContributionManager(address who);
     event AddContribution(bytes32 indexed contributionId, bytes encodedContributionStatus);
     event RemoveContribution(bytes32 indexed contributionId, bytes encodedContributionStatus);
     event CommitContribution(bytes32 indexed contributionId, address indexed sender, address indexed who, bytes data);
@@ -56,13 +56,13 @@ interface ITaskManager {
     /// @notice Get the amount of contribution points removed for the current period
     function periodPointsRemoved() external view returns (uint128);
 
-    function addContributor(address who) external;
+    function addContributionManager(address who) external;
 
-    function removeContributor(address who) external;
+    function removeContributionManager(address who) external;
 
-    function isContributor(address who) external view returns (bool);
+    function isContributionManager(address who) external view returns (bool);
 
-    function contributors() external view returns (address[] memory);
+    function contributionManagers() external view returns (address[] memory);
 
     /// @notice Add a contribution to the manager
     /// @dev is called via TaskFactory

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -31,10 +31,15 @@ interface ITaskManager {
     error UnequalLengths();
     error MemberAlreadyContributed();
     error ContributionNotOpen();
+    error AlreadyContributor();
+    error NotContributor();
+    error UnauthorizedContributor();
 
+    event AddContributor(address who);
+    event RemoveContributor(address who);
     event AddContribution(bytes32 indexed contributionId, bytes encodedContributionStatus);
     event RemoveContribution(bytes32 indexed contributionId, bytes encodedContributionStatus);
-    event CommitContribution(bytes32 indexed contributionId, address indexed who, bytes data);
+    event CommitContribution(bytes32 indexed contributionId, address indexed sender, address indexed who, bytes data);
     event GiveContribution(
         bytes32 indexed contributionId,
         address indexed who,
@@ -51,6 +56,14 @@ interface ITaskManager {
     /// @notice Get the amount of contribution points removed for the current period
     function periodPointsRemoved() external view returns (uint128);
 
+    function addContributor(address who) external;
+
+    function removeContributor(address who) external;
+
+    function isContributor(address who) external view returns (bool);
+
+    function contributors() external view returns (address[] memory);
+
     /// @notice Add a contribution to the manager
     /// @dev is called via TaskFactory
     function addContribution(bytes32 contributionId, Contribution calldata contribution) external;
@@ -62,10 +75,14 @@ interface ITaskManager {
     function removeContribution(bytes32 contributionId) external;
 
     /// @notice Commit to a set of open contributions with associated data
-    function commitContributions(bytes32[] calldata contributionIds, bytes[] calldata datas) external;
+    function commitContributions(
+        bytes32[] calldata contributionIds,
+        address[] calldata whos,
+        bytes[] calldata datas
+    ) external;
 
     /// @notice Commit to an open contribution with associated data
-    function commitContribution(bytes32 contributionId, bytes calldata data) external;
+    function commitContribution(bytes32 contributionId, address who, bytes calldata data) external;
 
     /// @notice Give contribution points to members who have completed the contribution requirements
     function giveContributions(bytes32[] calldata contributionIds, address[] calldata whos) external;


### PR DESCRIPTION
Feature to add a `contributionManager` role.  Current spec is as follows:
- Hub `admin` has the ability to add/remove `contributionManager`(s)
- Hub member, `contributionManager`, and `admin` are all allowed to call `commitContribution` on the behalf of the hub member.
- `contributionManager` and `admin` are allowed to call `giveContribution` for a hub member.

cc @AntGe 