### PR TITLE
feat: initialContributionManager

### DIFF
--- a/contracts/hub/HubRegistry.sol
+++ b/contracts/hub/HubRegistry.sol
@@ -12,6 +12,7 @@ import {
 
 import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
 import {IGlobalParameters} from "../globalParameters/IGlobalParameters.sol";
+import {ITaskManager} from "../tasks/interfaces/ITaskManager.sol";
 
 import {IHub} from "./interfaces/IHub.sol";
 import {IHubModule} from "./interfaces/IHubModule.sol";
@@ -39,6 +40,7 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
     address public hubDomainsRegistry;
     address public taskRegistry;
     address public globalParameters;
+    address public initialContributionManager;
     address public membershipImplementation;
     address public participationImplementation;
     address public taskFactoryImplementation;
@@ -53,6 +55,7 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
         address hubDomainsRegistry_,
         address taskRegistry_,
         address globalParameters_,
+        address _initialContributionManager,
         address _membershipImplementation,
         address _participationImplementation,
         address _taskFactoryImplementation,
@@ -69,10 +72,16 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
         globalParameters = globalParameters_;
         upgradeableBeacon = new UpgradeableBeacon(hubLogic, address(this));
 
+        setInitialContributionManager(_initialContributionManager);
+
         membershipImplementation = _membershipImplementation;
         participationImplementation = _participationImplementation;
         taskFactoryImplementation = _taskFactoryImplementation;
         taskManagerImplementation = _taskManagerImplementation;
+    }
+
+    function setInitialContributionManager(address _initialContributionManager) public onlyOwner {
+        initialContributionManager = _initialContributionManager;
     }
 
     function currentPeriodId() public view returns (uint32) {
@@ -134,6 +143,9 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
             _participation: participation,
             _membership: membership
         });
+
+        // Set the initial contribution manager as stored in this contract
+        ITaskManager(taskManager).initialize2(initialContributionManager);
 
         hubDeployers[_msgSender()].push(hub);
         hubs.push(hub);

--- a/contracts/hub/interfaces/IHubRegistry.sol
+++ b/contracts/hub/interfaces/IHubRegistry.sol
@@ -8,6 +8,7 @@ interface IHubRegistry {
         address hubDomainsRegistry_,
         address taskRegistry_,
         address globalParameters_,
+        address _initialContributionManager,
         address _membershipImplementation,
         address _participationImplementation,
         address _taskFactoryImplementation,

--- a/contracts/tasks/TaskFactory.sol
+++ b/contracts/tasks/TaskFactory.sol
@@ -31,7 +31,7 @@ contract TaskFactory is ITaskFactory, Initializable, PeriodUtils, AccessUtils {
     function registerDescriptions(Description[] calldata descriptions) external returns (bytes32[] memory) {
         uint256 length = descriptions.length;
         bytes32[] memory newDescriptionIds = new bytes32[](length);
-        for (uint256 i=0; i < length; i++) {
+        for (uint256 i = 0; i < length; i++) {
             newDescriptionIds[i] = _registerDescription(descriptions[i]);
         }
 

--- a/contracts/tasks/TaskManager.sol
+++ b/contracts/tasks/TaskManager.sol
@@ -34,12 +34,20 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
         _init_PeriodUtils({_period0Start: _period0Start, _initPeriodId: _initPeriodId});
     }
 
+    /// @dev set the initial contribution manager from the hub registry
+    function initialize2(address initialContributionManager) external reinitializer(2) {
+        _addContributionManager(initialContributionManager);
+    }
+
     // ContributionManager-management
 
     function addContributionManager(address who) external {
         _revertIfNotAdmin();
-        if (!_contributionManagers.add(who)) revert AlreadyContributionManager();
+        _addContributionManager(who);
+    }
 
+    function _addContributionManager(address who) internal {
+        if (!_contributionManagers.add(who)) revert AlreadyContributionManager();
         emit AddContributionManager(who);
     }
 

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -47,6 +47,9 @@ interface ITaskManager {
         bytes encodedContributionStatus
     );
 
+    /// @notice Set the initial contribution manager from the hub registry
+    function initialize2(address _initialContributionManager) external;
+
     /// @notice Get the amount of outstanding contribution points for the current period
     function pointsActive() external view returns (uint128);
 

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -23,6 +23,7 @@ import "forge-std/Script.sol";
 
 contract DeployAll is Script {
     address public owner;
+    address public initialContributionManager;
     uint256 public privateKey;
     bool public deploying;
 
@@ -50,13 +51,16 @@ contract DeployAll is Script {
     function setUp() public {
         if (block.chainid == 137) {
             owner = vm.envAddress("MAINNET_OWNER_ADDRESS");
+            initialContributionManager = vm.envAddress("MAINNET_INITIAL_CONTRIBUTION_MANAGER");
             privateKey = vm.envUint("MAINNET_PRIVATE_KEY");
         } else if (block.chainid == 80002) {
             owner = vm.envAddress("TESTNET_OWNER_ADDRESS");
+            initialContributionManager = vm.envAddress("TESTNET_INITIAL_CONTRIBUTION_MANAGER");
             privateKey = vm.envUint("TESTNET_PRIVATE_KEY");
         } else {
             // testing
             owner = address(123456);
+            initialContributionManager = address(11111111);
             privateKey = 567890;
         }
         console.log("setUp -- done");
@@ -86,6 +90,7 @@ contract DeployAll is Script {
             _hubDomainsRegistryAddress: address(hubDomainsRegistry),
             _taskRegistryAddress: address(taskRegistry),
             _globalParametersAddress: address(globalParameters),
+            _initialContributionManager: initialContributionManager,
             _membershipImplementation: membershipImplementation,
             _participationImplementation: participationImplementation,
             _taskFactoryImplementation: taskFactoryImplementation,
@@ -205,6 +210,7 @@ function deployHubRegistry(
     address _hubDomainsRegistryAddress,
     address _taskRegistryAddress,
     address _globalParametersAddress,
+    address _initialContributionManager,
     address _membershipImplementation,
     address _participationImplementation,
     address _taskFactoryImplementation,
@@ -223,6 +229,7 @@ function deployHubRegistry(
                 _hubDomainsRegistryAddress,
                 _taskRegistryAddress,
                 _globalParametersAddress,
+                _initialContributionManager,
                 _membershipImplementation,
                 _participationImplementation,
                 _taskFactoryImplementation,


### PR DESCRIPTION
Initializes a `contributionManager` upon hub creation to support bot management of `giveContribution` and `commitContribution` out-of-the-box.  This means every hub will have a starting `contributionManager` as configured by the owner of the `HubRegistry`, presumably our team.

Requires: additional environment variables of `MAINNET_INITIAL_CONTRIBUTION_MANAGER` and `TESTNET_INITIAL_CONTRIBUTION_MANAGER`

@mrtmeeseeks @AntGe 