### PR TITLE
feat: isMemberGivenContributionId

### DIFF
--- a/contracts/tasks/TaskManager.sol
+++ b/contracts/tasks/TaskManager.sol
@@ -274,6 +274,16 @@ contract TaskManager is ITaskManager, Initializable, PeriodUtils, AccessUtils {
     }
 
     /// @inheritdoc ITaskManager
+    function isMemberGivenContributionId(address who, bytes32 contributionId) external view returns (bool) {
+        return memberContributions[who].contains(contributionId);
+    }
+
+    /// @inheritdoc ITaskManager
+    function getMemberContributionIds(address who) external view returns (bytes32[] memory) {
+        return memberContributions[who].values();
+    }
+
+    /// @inheritdoc ITaskManager
     function getMemberContributionIds(address who, uint32 periodId) external view returns (bytes32[] memory) {
         return memberActivities[who][periodId].contributionIds;
     }

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -116,6 +116,13 @@ interface ITaskManager {
     /// @notice return the amount of points a member has been given for a provided periodId
     function getMemberPointsGiven(address who, uint32 periodId) external view returns (uint128);
 
+    /// @notice return true if a member has been given a specific contributionId
+    /// @dev each member can only receive a unique contributionId once
+    function isMemberGivenContributionId(address who, bytes32 contributionId) external view returns (bool);
+
+    /// @notice return the contributionId's given to a member across all periods
+    function getMemberContributionIds(address who) external view returns (bytes32[] memory);
+
     /// @notice return the contributionId's given to a member for a provided periodId
     function getMemberContributionIds(address who, uint32 periodId) external view returns (bytes32[] memory);
 


### PR DESCRIPTION
Adds a view to query if a member has been given a specific `contributionId`.

Note that this does *not* return the period in which the `contributionId` is given.

cc @AntGe 