### PR TITLE
feat: `revokeContribution()`

### DIFF
--- a/contracts/hub/HubDomainsRegistry.sol
+++ b/contracts/hub/HubDomainsRegistry.sol
@@ -21,11 +21,7 @@ contract HubDomainsRegistry is IHubDomainsRegistry, Initializable, ERC721Upgrade
         _disableInitializers();
     }
 
-    function initialize(
-        address _hubRegistry,
-        string memory name_,
-        string memory symbol_
-    ) external initializer {
+    function initialize(address _hubRegistry, string memory name_, string memory symbol_) external initializer {
         hubRegistry = _hubRegistry;
 
         __ERC721_init(name_, symbol_);
@@ -37,11 +33,7 @@ contract HubDomainsRegistry is IHubDomainsRegistry, Initializable, ERC721Upgrade
     }
 
     /// @inheritdoc IHubDomainsRegistry
-    function registerDomain(
-        string calldata _name,
-        string calldata _uri,
-        address _owner
-    ) external onlyFromHub {
+    function registerDomain(string calldata _name, string calldata _uri, address _owner) external onlyFromHub {
         require(domains[msg.sender].tokenId == 0, "Domain already registered");
         require(_isValidDomain(_name), "Invalid _name format");
 

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -29,11 +29,13 @@ struct MemberActivity {
 
 interface ITaskManager {
     error UnequalLengths();
-    error MemberAlreadyContributed();
     error ContributionNotOpen();
     error AlreadyContributionManager();
     error NotContributionManager();
     error UnauthorizedContributionManager();
+    error ContributionAlreadyCommitted();
+    error ContributionAlreadyGiven();
+    error ContributionNotCommitted();
 
     event AddContributionManager(address who);
     event RemoveContributionManager(address who);
@@ -54,6 +56,13 @@ interface ITaskManager {
         uint128 quantityRemaining
     );
     event CommitContribution(
+        bytes32 indexed contributionId,
+        address indexed sender,
+        address indexed hub,
+        address who,
+        bytes data
+    );
+    event RevokeContribution(
         bytes32 indexed contributionId,
         address indexed sender,
         address indexed hub,
@@ -118,6 +127,16 @@ interface ITaskManager {
 
     /// @notice Commit to an open Contribution with associated data
     function commitContribution(bytes32 contributionId, address who, bytes calldata data) external;
+
+    /// @notice Revoke a set of commits to contributions(commitContribution(s))
+    function revokeContributions(
+        bytes32[] calldata contributionIds,
+        address[] calldata wwhos,
+        bytes[] calldata datas
+    ) external;
+
+    /// @notice Revoke a commit to contribution (commitContribution())
+    function revokeContribution(bytes32 contributionId, address who, bytes calldata data) external;
 
     /// @notice Give Contribution points to members who have completed the Contribution requirements
     function giveContributions(bytes32[] calldata contributionIds, address[] calldata whos) external;


### PR DESCRIPTION
Feature to enable revoking a commitment to a contribution.  Adds the following requirements:
- A member can only commit to a `contributionId` once.
- A member cannot commit to a `contributionId` if they have been given the `contributionId`.
- A member can revoke their commitment through `revokeContribution()`
- Contributions can only be given to members who have outstanding commitments

cc @Jabyl @mrtmeeseeks @AntGe 