### PR TITLE
refactor: remove universal period

### DIFF
--- a/contracts/globalParameters/GlobalParameters.sol
+++ b/contracts/globalParameters/GlobalParameters.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./IGlobalParameters.sol";
-import {TimeLibrary} from "../libraries/TimeLibrary.sol";
 
 contract GlobalParameters is IGlobalParameters, OwnableUpgradeable {
     // slot 1
@@ -33,7 +32,6 @@ contract GlobalParameters is IGlobalParameters, OwnableUpgradeable {
     // Slot 3
     uint64 public credibleNeutrality6ExpExpiresAt;
 
-    uint32 public period0Start;
     uint128 public penaltyFactor;
     uint128 public constraintFactor;
 
@@ -56,9 +54,6 @@ contract GlobalParameters is IGlobalParameters, OwnableUpgradeable {
 
     /// @dev fill with default values
     function initialize() external initializer {
-        period0Start = TimeLibrary.periodStart({timestamp: uint32(block.timestamp)});
-        periodDuration = TimeLibrary.FOUR_WEEKS;
-
         constraintFactor = 4e17; // 40%
         penaltyFactor = 4e17; // 40%
 
@@ -67,10 +62,6 @@ contract GlobalParameters is IGlobalParameters, OwnableUpgradeable {
         penaltyFactor3Exp = 600; // TODO: scale properly
         constrainingFactor6Exp = 1_400_000;
         credibleNeutrality6Exp = 1_300_000;
-    }
-
-    function currentPeriodId() external view returns (uint32) {
-        return TimeLibrary.periodId({period0Start: period0Start, timestamp: uint32(block.timestamp)});
     }
 
     function stagePeriodDuration(uint32 nextPeriodDuration) external {

--- a/contracts/globalParameters/IGlobalParameters.sol
+++ b/contracts/globalParameters/IGlobalParameters.sol
@@ -34,8 +34,6 @@ interface IGlobalParameters {
     event PrestigeForPeriod0Unstaged();
     event PrestiveForPeriod0Committed();
 
-    function period0Start() external view returns (uint32);
-    function currentPeriodId() external view returns (uint32);
     function constraintFactor() external view returns (uint128);
     function penaltyFactor() external view returns (uint128);
 

--- a/contracts/hub/Hub.sol
+++ b/contracts/hub/Hub.sol
@@ -9,11 +9,12 @@ import {IGlobalParameters} from "../globalParameters/IGlobalParameters.sol";
 import {IMembership} from "../membership/IMembership.sol";
 // import {OnboardingModule} from "../modules/onboarding/OnboardingModule.sol";
 import {HubUtils} from "./HubUtils.sol";
+import {PeriodUtils} from "../utils/PeriodUtils.sol";
 import {IHub} from "./interfaces/IHub.sol";
 import {ITaskManager} from "../tasks/interfaces/ITaskManager.sol";
 import {Domain, IHubDomainsRegistry} from "./interfaces/IHubDomainsRegistry.sol";
 
-contract Hub is IHub, HubUtils, OwnableUpgradeable, HubUpgradeable {
+contract Hub is IHub, HubUtils, PeriodUtils, OwnableUpgradeable, HubUpgradeable {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.UintSet;
 
@@ -40,9 +41,6 @@ contract Hub is IHub, HubUtils, OwnableUpgradeable, HubUpgradeable {
         uint256 archetype;
         uint256 market;
         string uri;
-        uint32 initTimestamp;
-        uint32 initPeriodId;
-        uint32 period0Start;
         EnumerableSet.AddressSet admins;
         EnumerableSet.UintSet roles;
         string[] urls;
@@ -94,9 +92,7 @@ contract Hub is IHub, HubUtils, OwnableUpgradeable, HubUpgradeable {
         _setCommitment(_commitment);
         _setUri(_uri);
 
-        $.initTimestamp = uint32(block.timestamp);
-        $.period0Start = IGlobalParameters(_globalParameters).period0Start();
-        $.initPeriodId = TimeLibrary.periodId({period0Start: $.period0Start, timestamp: uint32(block.timestamp)});
+        _init_PeriodUtils();
     }
 
     /// @dev contracts specific to this hub
@@ -242,21 +238,6 @@ contract Hub is IHub, HubUtils, OwnableUpgradeable, HubUpgradeable {
         return $.uri;
     }
 
-    function initTimestamp() external view returns (uint32) {
-        HubStorage storage $ = _getHubStorage();
-        return $.initTimestamp;
-    }
-
-    function initPeriodId() external view returns (uint32) {
-        HubStorage storage $ = _getHubStorage();
-        return $.initPeriodId;
-    }
-
-    function period0Start() external view returns (uint32) {
-        HubStorage storage $ = _getHubStorage();
-        return $.period0Start;
-    }
-
     /// @inheritdoc IHub
     function membersCount() external view returns (uint256) {
         return IMembership(membership()).membersCount();
@@ -283,11 +264,11 @@ contract Hub is IHub, HubUtils, OwnableUpgradeable, HubUpgradeable {
         return currentRole(who) == role;
     }
 
-    function hadRole(address who, uint256 role, uint32 periodId) external view returns (bool) {
+    function hadRole(address who, uint256 role, uint32 period) external view returns (bool) {
         // TODO
     }
 
-    function roleAtPeriod(address who, uint32 periodId) public view returns (uint256) {
+    function roleAtPeriod(address who, uint32 period) public view returns (uint256) {
         // TODO
     }
 

--- a/contracts/hub/HubRegistry.sol
+++ b/contracts/hub/HubRegistry.sol
@@ -95,18 +95,6 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
     }
 
     /// @inheritdoc IHubRegistry
-    function currentPeriodId() public view returns (uint32) {
-        HubRegistryStorage storage $ = _getHubRegistryStorage();
-        return IGlobalParameters($.globalParameters).currentPeriodId();
-    }
-
-    /// @inheritdoc IHubRegistry
-    function period0Start() public view returns (uint32) {
-        HubRegistryStorage storage $ = _getHubRegistryStorage();
-        return IGlobalParameters($.globalParameters).period0Start();
-    }
-
-    /// @inheritdoc IHubRegistry
     function deployHub(
         uint256[] calldata roles,
         uint256 market,
@@ -134,7 +122,7 @@ contract HubRegistry is IHubRegistry, ERC2771ContextUpgradeable, OwnableUpgradea
         hub = address(new BeaconProxy(address($.upgradeableBeacon), data));
 
         // data for all hub-owned modules
-        data = abi.encodeCall(IHubModule.initialize, (hub, period0Start(), currentPeriodId()));
+        data = abi.encodeCall(IHubModule.initialize, (hub));
 
         // deploy taskFactory
         address taskFactory = address(new AutProxy($.taskFactoryImplementation, _msgSender(), data));

--- a/contracts/hub/interfaces/IHubModule.sol
+++ b/contracts/hub/interfaces/IHubModule.sol
@@ -1,5 +1,5 @@
 pragma solidity >=0.8.0;
 
 interface IHubModule {
-    function initialize(address, uint32, uint32) external;
+    function initialize(address) external;
 }

--- a/contracts/hub/interfaces/IHubRegistry.sol
+++ b/contracts/hub/interfaces/IHubRegistry.sol
@@ -32,12 +32,6 @@ interface IHubRegistry {
     /// @dev only callable by Hub owner
     function setInitialContributionManager(address _initialContributionManager) external;
 
-    /// @notice return the current period id (as stored globally)
-    function currentPeriodId() external view returns (uint32);
-
-    /// @notice return the timestamp of when period id 0 begins (as stored globally)
-    function period0Start() external view returns (uint32);
-
     /// @notice return the array of hubs created through the registry
     /// @dev supports subgraph queries
     function hubs() external view returns (address[] memory);

--- a/contracts/libraries/TimeLibrary.sol
+++ b/contracts/libraries/TimeLibrary.sol
@@ -6,23 +6,21 @@ library TimeLibrary {
     uint32 internal constant FOUR_WEEKS = 28 days;
 
     /// @notice Round down the timestamp passed to the start of the period
-    function periodStart(uint32 timestamp) internal pure returns (uint32) {
-        unchecked {
-            return timestamp - (timestamp % FOUR_WEEKS);
-        }
+    function periodStart(uint32 currentTimestamp, uint32 initTimestamp) internal pure returns (uint32) {
+        return initTimestamp + numPeriodsCompleted(currentTimestamp, initTimestamp) * FOUR_WEEKS;
     }
 
-    /// @notice Round up the timestamp passed to the end of the period
-    function periodEnd(uint32 timestamp) internal pure returns (uint32) {
-        unchecked {
-            return periodStart({timestamp: timestamp}) + FOUR_WEEKS;
-        }
+    function periodEnd(uint32 currentTimestamp, uint32 initTimestamp) internal pure returns (uint32) {
+        return periodStart(currentTimestamp, initTimestamp) + FOUR_WEEKS;
+    }
+
+    /// @dev returns the number of full periods betwen the init and current time
+    function numPeriodsCompleted(uint32 currentTimestamp, uint32 initTimestamp) internal pure returns (uint32) {
+        return (currentTimestamp - initTimestamp) / FOUR_WEEKS;
     }
 
     /// @dev returns the id of the current period, starting at 1
-    function periodId(uint32 period0Start, uint32 timestamp) internal pure returns (uint32) {
-        unchecked {
-            return (((periodStart({timestamp: timestamp}) - period0Start) / FOUR_WEEKS) + 1);
-        }
+    function periodId(uint32 currentTimestamp, uint32 initTimestamp) internal pure returns (uint32) {
+        return numPeriodsCompleted(currentTimestamp, initTimestamp) + 1;
     }
 }

--- a/contracts/membership/IMembership.sol
+++ b/contracts/membership/IMembership.sol
@@ -13,6 +13,7 @@ interface IMembership {
     error TooLateCommitmentChange();
     error SameCommitment();
     error InvalidCommitment();
+    error InvalidPeriodId();
 
     event ChangeCommitment(address indexed who, uint8 oldCommitment, uint8 newCommitment);
 
@@ -33,25 +34,22 @@ interface IMembership {
     function membersCount() external view returns (uint256);
 
     /// @notice Get the period ID of when the member joined the hub
-    function getPeriodIdJoined(address who) external view returns (uint32 periodId);
+    function getPeriodJoined(address who) external view returns (uint32 period);
 
     /// @notice Get the period ID of when an array of members joined the hub
-    function getPeriodIdsJoined(address[] calldata whos) external view returns (uint32[] memory);
+    function getPeriodsJoined(address[] calldata whos) external view returns (uint32[] memory);
 
     /// @notice get the commitment level of a member at a particular period id
-    function getCommitment(address who, uint32 periodId) external view returns (uint8 commitment);
+    function getCommitment(address who, uint32 period) external view returns (uint8 commitment);
 
     /// @notice get the commitment level of an array of members at a particular period id
-    function getCommitments(
-        address[] calldata whos,
-        uint32[] calldata periodIds
-    ) external view returns (uint8[] memory);
+    function getCommitments(address[] calldata whos, uint32[] calldata periods) external view returns (uint8[] memory);
 
     /// @notice get the cumulative commitment by members at a given period id
-    function getCommitmentSum(uint32 periodId) external view returns (uint128 commitmentSum);
+    function getCommitmentSum(uint32 period) external view returns (uint128 commitmentSum);
 
     /// @notice get the cumulative commitment by members at an array of given period ids
-    function getCommitmentSums(uint32[] calldata periodIds) external view returns (uint128[] memory);
+    function getCommitmentSums(uint32[] calldata periods) external view returns (uint128[] memory);
 
     /// @notice Join the hub
     /// @dev Is called through the hub

--- a/contracts/participationScore/IParticipationScore.sol
+++ b/contracts/participationScore/IParticipationScore.sol
@@ -8,6 +8,7 @@ struct MemberParticipation {
 
 interface IParticipationScore {
     error InvalidCommitment();
+    error InvalidPeriodId();
 
     /// @notice called when a member joins a hub
     function join(address who) external;
@@ -16,52 +17,46 @@ interface IParticipationScore {
     function calcPerformanceInPeriod(
         uint32 commitment,
         uint128 pointsGiven,
-        uint32 periodId
+        uint32 period
     ) external view returns (uint128);
 
     /// @notice helper to predict performance score for any members
     function calcPerformancesInPeriod(
         uint32[] calldata commitments,
         uint128[] calldata pointsGiven,
-        uint32 periodId
+        uint32 period
     ) external view returns (uint128[] memory);
 
     /// @notice Calculate the performance score for a member of a given period
     /// @dev returns with 1e18 precision
-    function calcPerformanceInPeriod(address who, uint32 periodId) external view returns (uint128);
+    function calcPerformanceInPeriod(address who, uint32 period) external view returns (uint128);
 
     /// @notice Calculate the performance score for a member of a given array of periods
-    function calcPerformanceInPeriods(
-        address who,
-        uint32[] calldata periodIds
-    ) external view returns (uint128[] memory);
+    function calcPerformanceInPeriods(address who, uint32[] calldata periods) external view returns (uint128[] memory);
 
     /// @notice Calculate the performance score for an array of members of a given period
-    function calcPerformancesInPeriod(
-        address[] calldata whos,
-        uint32 periodId
-    ) external view returns (uint128[] memory);
+    function calcPerformancesInPeriod(address[] calldata whos, uint32 period) external view returns (uint128[] memory);
 
     /// @notice calculate the fractional commitment * total points active in a period
-    function calcExpectedPoints(uint32 commitment, uint32 periodId) external view returns (uint128);
+    function calcExpectedPoints(uint32 commitment, uint32 period) external view returns (uint128);
 
     /// @notice Calculate an array of fractional commitments * total points active for an array of periods
     function calcsExpectedPoints(
         uint32[] calldata commitments,
-        uint32[] calldata periodIds
+        uint32[] calldata periods
     ) external view returns (uint128[] memory);
 
     /// @notice Calculate the percentage a commitment is to the whole of the hub for a period
-    function fractionalCommitment(uint32 commitment, uint32 periodId) external view returns (uint128);
+    function fractionalCommitment(uint32 commitment, uint32 period) external view returns (uint128);
 
     /// @notice Calculate an array of percentages of commitments are to the whole of the hub for an array of periods
     function fractionalsCommitments(
         uint32[] calldata commitments,
-        uint32[] calldata periodIds
+        uint32[] calldata periods
     ) external view returns (uint128[] memory);
 
     /// @notice off-chain helper to check which members to write historical participation score to
-    function getMembersToWriteMemberParticipation(uint32 periodId) external view returns (address[] memory);
+    function getMembersToWriteMemberParticipation(uint32 period) external view returns (address[] memory);
 
     /// @notice write the historical participation (score and performance) of a member to storage
     function writeMemberParticipation(address who) external;

--- a/contracts/tasks/TaskFactory.sol
+++ b/contracts/tasks/TaskFactory.sol
@@ -14,7 +14,7 @@ contract TaskFactory is ITaskFactory, Initializable, PeriodUtils, AccessUtils {
 
     EnumerableSet.Bytes32Set private _contributionIds;
     mapping(bytes32 => Contribution) public _contributions;
-    mapping(uint32 periodId => bytes32[] contributionIds) public _contributionIdsInPeriod;
+    mapping(uint32 period => bytes32[] contributionIds) public _contributionIdsInPeriod;
 
     function version() external pure returns (uint256 major, uint256 minor, uint256 patch) {
         return (0, 1, 2);
@@ -24,9 +24,9 @@ contract TaskFactory is ITaskFactory, Initializable, PeriodUtils, AccessUtils {
         _disableInitializers();
     }
 
-    function initialize(address _hub, uint32 _period0Start, uint32 _initPeriodId) external initializer {
+    function initialize(address _hub) external initializer {
         _init_AccessUtils({_hub: _hub, _autId: address(0)});
-        _init_PeriodUtils({_period0Start: _period0Start, _initPeriodId: _initPeriodId});
+        _init_PeriodUtils();
     }
 
     /// @inheritdoc ITaskFactory
@@ -149,8 +149,8 @@ contract TaskFactory is ITaskFactory, Initializable, PeriodUtils, AccessUtils {
     }
 
     /// @inheritdoc ITaskFactory
-    function contributionIdsInPeriod(uint32 periodId) external view returns (bytes32[] memory) {
-        return _contributionIdsInPeriod[periodId];
+    function contributionIdsInPeriod(uint32 period) external view returns (bytes32[] memory) {
+        return _contributionIdsInPeriod[period];
     }
 
     /// @inheritdoc ITaskFactory

--- a/contracts/tasks/interfaces/ITaskFactory.sol
+++ b/contracts/tasks/interfaces/ITaskFactory.sol
@@ -58,7 +58,7 @@ interface ITaskFactory {
     function contributionIds() external view returns (bytes32[] memory);
 
     /// @notice return all Contribution ids created within a given period
-    function contributionIdsInPeriod(uint32 periodId) external view returns (bytes32[] memory);
+    function contributionIdsInPeriod(uint32 period) external view returns (bytes32[] memory);
 
     /// @notice convert a Contribution struct to its' encoded type to hash / events
     function encodeContribution(Contribution memory contribution) external pure returns (bytes memory);

--- a/contracts/tasks/interfaces/ITaskManager.sol
+++ b/contracts/tasks/interfaces/ITaskManager.sol
@@ -73,7 +73,7 @@ interface ITaskManager {
         bytes32 indexed contributionId,
         address indexed sender,
         address indexed hub,
-        uint32 periodId,
+        uint32 period,
         address who,
         Status status,
         uint32 points,
@@ -150,14 +150,14 @@ interface ITaskManager {
     /// @notice return the ContributionStatus of a given contributionId
     function getContributionStatus(bytes32 contributionId) external view returns (ContributionStatus memory);
 
-    /// @notice Return the MemberActivity of a given address and periodId
-    function getMemberActivity(address who, uint32 periodId) external view returns (MemberActivity memory);
+    /// @notice Return the MemberActivity of a given address and period
+    function getMemberActivity(address who, uint32 period) external view returns (MemberActivity memory);
 
     /// @notice return the amount of points associated to a contributionId
     function getContributionPoints(bytes32 contributionId) external view returns (uint128);
 
-    /// @notice return the amount of points a member has been given for a provided periodId
-    function getMemberPointsGiven(address who, uint32 periodId) external view returns (uint128);
+    /// @notice return the amount of points a member has been given for a provided period
+    function getMemberPointsGiven(address who, uint32 period) external view returns (uint128);
 
     /// @notice return true if a member has been given a specific contributionId
     /// @dev each member can only receive a unique contributionId once
@@ -166,15 +166,15 @@ interface ITaskManager {
     /// @notice return the contributionId's given to a member across all periods
     function getMemberContributionIds(address who) external view returns (bytes32[] memory);
 
-    /// @notice return the contributionId's given to a member for a provided periodId
-    function getMemberContributionIds(address who, uint32 periodId) external view returns (bytes32[] memory);
+    /// @notice return the contributionId's given to a member for a provided period
+    function getMemberContributionIds(address who, uint32 period) external view returns (bytes32[] memory);
 
-    /// @notice return the amount of outstanding contribution points for a provided periodId
-    function getPointsActive(uint32 periodId) external view returns (uint128);
+    /// @notice return the amount of outstanding contribution points for a provided period
+    function getPointsActive(uint32 period) external view returns (uint128);
 
-    /// @notice return the amount of given contribution points for a provided periodId
-    function getPointsGiven(uint32 periodId) external view returns (uint128);
+    /// @notice return the amount of given contribution points for a provided period
+    function getPointsGiven(uint32 period) external view returns (uint128);
 
-    /// @notice return the contributionId's given for the whole hub for a provided periodId
-    function getGivenContributions(uint32 periodId) external view returns (bytes32[] memory);
+    /// @notice return the contributionId's given for the whole hub for a provided period
+    function getGivenContributions(uint32 period) external view returns (bytes32[] memory);
 }

--- a/contracts/utils/interfaces/IPeriodUtils.sol
+++ b/contracts/utils/interfaces/IPeriodUtils.sol
@@ -2,6 +2,24 @@
 pragma solidity >=0.8.0;
 
 interface IPeriodUtils {
-    function currentPeriodId() external view returns (uint32 periodId);
-    function getPeriodId(uint32 timestamp) external view returns (uint32 periodId);
+    /// @notice Get the start time of the curent period
+    function currentPeriodStart() external view returns (uint32);
+
+    /// @notice Get the end time of the current period
+    function currentPeriodEnd() external view returns (uint32);
+
+    /// @notice Get the current period id (starting at 1)
+    function currentPeriodId() external view returns (uint32);
+
+    /// @notice Get the start time of a period which contains the timestamp
+    function periodStart(uint32 timestamp) external view returns (uint32);
+
+    /// @notice Get the end time of a period which contains the timestamp
+    function periodEnd(uint32 timestamp) external view returns (uint32);
+
+    /// @notice Get the period id for a given timestamp
+    function periodId(uint32 timestamp) external view returns (uint32);
+
+    /// @notice Get the timestamp of hub creation
+    function initTimestamp() external view returns (uint32);
 }

--- a/test/unit/tasks/TaskFactory/CreateContributionsTest.t.sol
+++ b/test/unit/tasks/TaskFactory/CreateContributionsTest.t.sol
@@ -42,8 +42,8 @@ contract TaskFactoryCreateContributionsTest is BaseTest {
         bytes32[] memory contributionIds = taskFactory.contributionIds();
         assertEq(contributionIds.length, 0);
         
-        uint32 currentPeriodId = taskFactory.currentPeriodId();
-        bytes32[] memory contributionIdsInPeriod = taskFactory.contributionIdsInPeriod(currentPeriodId);
+        uint32 currentPeriod = taskFactory.currentPeriodId();
+        bytes32[] memory contributionIdsInPeriod = taskFactory.contributionIdsInPeriod(currentPeriod);
         assertEq(contributionIdsInPeriod.length, 0);
 
         // action
@@ -67,7 +67,7 @@ contract TaskFactoryCreateContributionsTest is BaseTest {
         assertEq(contributionIds.length, 1);
         assertEq(contributionIds[0], contributionId);
 
-        contributionIdsInPeriod = taskFactory.contributionIdsInPeriod(currentPeriodId);
+        contributionIdsInPeriod = taskFactory.contributionIdsInPeriod(currentPeriod);
         assertEq(contributionIdsInPeriod.length, 1);
         assertEq(contributionIdsInPeriod[0], contributionId);
     }

--- a/test/unit/tasks/TaskManager/GiveContributionTest.t.sol
+++ b/test/unit/tasks/TaskManager/GiveContributionTest.t.sol
@@ -54,10 +54,10 @@ contract TaskManagerGiveContributionTest is BaseTest {
     }
 
     function test_GiveContribution_succeeds() public {
-        uint32 currentPeriodId = taskManager.currentPeriodId();
+        uint32 currentPeriod = taskManager.currentPeriodId();
 
         // pre-action asserts
-        MemberActivity memory memberActivity = taskManager.getMemberActivity(bob, currentPeriodId);
+        MemberActivity memory memberActivity = taskManager.getMemberActivity(bob, currentPeriod);
         assertEq(memberActivity.pointsGiven, 0);
         assertEq(memberActivity.contributionIds.length, 0);
 
@@ -69,7 +69,7 @@ contract TaskManagerGiveContributionTest is BaseTest {
         });
 
         // post-action asserts (TODO)
-        // memberActivity = taskManager.getMemberActivity(bob, currentPeriodId);
+        // memberActivity = taskManager.getMemberActivity(bob, currentPeriod);
         // assertEq(memberActivity.pointsGiven, points);
         // assertEq(memberActivity.contributionIds.length, 1);
         // assertEq(memberActivity.contributionIds[0], contributionId);


### PR DESCRIPTION
This PR is a refactor to change how a hub recognizes periods.

Previously, there was a global `periodId()` shared across contracts which incremented based on a rounded-down timestamp.  This means, for example, that the protocol is initialized at period 1, and a hub can be created halfway through period X.  From this, the hub would have (a) a starting period ID greater than 1 and (b) a first period shorter than 28 days as the period changes based on the global timestamp.

Now, when a hub is created it will have a starting period ID of 1 that always lasts 28 days.  This means that (a) one hubs' period is independent of another hub and (b) the hub period increments exactly 28 days after creation, not after the rounded-down timestamp.

cc @Jabyl @bengyles 